### PR TITLE
Update vue-column-sortable.js

### DIFF
--- a/src/vue-column-sortable.js
+++ b/src/vue-column-sortable.js
@@ -77,7 +77,7 @@ export default {
     initialElementStyle(el);
     vnode.context.$nextTick(()=>{
       const modifiers = Object.keys(binding.modifiers).join('.');
-      const sortKey = binding.arg + (modifiers ? `.${modifiers}` : '');
+      const sortKey = (binding.arg || binding.value) + (modifiers ? `.${modifiers}` : '');
       callBackSortClass = changeSortClass.bind(el, sortKey, vnode, binding.value);
       el.addEventListener('click', callBackSortClass);
     })


### PR DESCRIPTION
Allow dynamic column names:

`<th v-for="column in columns" v-column-sortable="column.key">{{ column.title }}</th>`